### PR TITLE
correct header

### DIFF
--- a/initsplit.el
+++ b/initsplit.el
@@ -1,4 +1,4 @@
-;;; initsplit --- code to split customizations into different files
+;;; initsplit.el --- code to split customizations into different files
 
 ;; Copyright (C) 2000, 2001 John Wiegley
 ;; Copyright (C) 2010, 2011 Dave Abrahams


### PR DESCRIPTION
for some reason if the first line is "initsplit", not "initsplit.el", then `package-install-file` gives the following error:

```
Debugger entered--Lisp error: (error "Packages lacks a file header")
  signal(error ("Packages lacks a file header"))
  error("Packages lacks a file header")
  package-buffer-info()
  package-install-file("~/melpa/packages/initsplit-20120616.el")
  call-interactively(package-install-file record nil)
  command-execute(package-install-file record)
  execute-extended-command(nil "package-install-file")
  call-interactively(execute-extended-command nil nil)
```
