### PR TITLE
Fix find-if

### DIFF
--- a/initsplit.el
+++ b/initsplit.el
@@ -229,7 +229,7 @@ of the filename as with `load-library'."
 customization of a symbol whose name matches PATTERN.  The
 optional VISITED parameter is for internal use only and should
 always be nil when this function is not called recursively."
-  (find-if
+  (cl-find-if
    (lambda (option)
      (let ((x (car option)))
        (if (eq (cadr option) 'custom-group)


### PR DESCRIPTION
As find-if became obsolute to make it work with Emacs 26.3 cl-find-if is needed